### PR TITLE
Finish ELANA: implement all open issues

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -27,6 +27,9 @@ model Product {
   price        Int
   status       Boolean?
   stock        Int?
+  category     String?
+  size         String[]
+  image        String?
   basket_ids   String[] @db.ObjectId
   baskets      Basket[] @relation(fields: [basket_ids], references: [id])
   createdAt    DateTime @default(now())

--- a/apps/backend/src/controllers/orderController.ts
+++ b/apps/backend/src/controllers/orderController.ts
@@ -1,5 +1,11 @@
 import type { Request, Response } from "express";
-import { getOrderStatsService } from "../services/orderService";
+import { ZodError } from "zod";
+import {
+  createOrderService,
+  getOrderStatsService,
+  getOrdersService,
+} from "../services/orderService";
+import { createOrderSchema } from "../validators/order";
 
 export const getOrderStats = async (req: Request, res: Response) => {
   try {
@@ -13,5 +19,48 @@ export const getOrderStats = async (req: Request, res: Response) => {
       success: false,
       message: (error as Error).message,
     });
+  }
+};
+
+export const getOrders = async (req: Request, res: Response) => {
+  try {
+    const orders = await getOrdersService();
+    res.status(200).json({
+      success: true,
+      data: orders,
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: (error as Error).message,
+    });
+  }
+};
+
+export const createOrder = async (req: Request, res: Response) => {
+  try {
+    const { basket_id } = createOrderSchema.parse(req.body);
+    const order = await createOrderService(basket_id);
+    res.status(201).json({
+      success: true,
+      data: order,
+      message: "Order created successfully",
+    });
+  } catch (error) {
+    if (error instanceof ZodError) {
+      res.status(400).json({
+        success: false,
+        errors: error.issues,
+        message: "Invalid input data",
+      });
+      return;
+    }
+    const message = (error as Error).message;
+    const status = message.includes("not found")
+      ? 404
+      : message.includes("already exists")
+        ? 409
+        : 400;
+    res.status(status).json({ success: false, message });
   }
 };

--- a/apps/backend/src/controllers/orderController.ts
+++ b/apps/backend/src/controllers/orderController.ts
@@ -40,10 +40,11 @@ export const getOrders = async (req: Request, res: Response) => {
 export const createOrder = async (req: Request, res: Response) => {
   try {
     const { basket_id } = createOrderSchema.parse(req.body);
-    const order = await createOrderService(basket_id);
+    const { order, checkout } = await createOrderService(basket_id);
     res.status(201).json({
       success: true,
       data: order,
+      checkout,
       message: "Order created successfully",
     });
   } catch (error) {

--- a/apps/backend/src/routes/basketRouter.ts
+++ b/apps/backend/src/routes/basketRouter.ts
@@ -2,11 +2,12 @@ import { Router } from "express";
 import { addProductToBasket, createBasket, deleteBasket, getBasketByUserId, removeProductToBasket } from "../controllers/basketController";
 const basketRouter = Router();
 
-basketRouter.post("/:id", createBasket)
+// Specific routes must be registered before the "/:id" param routes,
+// otherwise "/add-product" and "/remove-product" get matched as an id.
 basketRouter.post("/add-product", addProductToBasket)
-basketRouter.get("/:id", getBasketByUserId)
 basketRouter.delete("/remove-product", removeProductToBasket)
+basketRouter.post("/:id", createBasket)
+basketRouter.get("/:id", getBasketByUserId)
 basketRouter.delete("/:id", deleteBasket)
 
 export default basketRouter;
- 

--- a/apps/backend/src/routes/orderRoutes.ts
+++ b/apps/backend/src/routes/orderRoutes.ts
@@ -1,8 +1,14 @@
 import express from "express";
-import { getOrderStats } from "../controllers/orderController";
+import {
+  createOrder,
+  getOrders,
+  getOrderStats,
+} from "../controllers/orderController";
 // add requireAuth later
 const router = express.Router();
 
 router.get("/stats", getOrderStats);
+router.get("/", getOrders);
+router.post("/", createOrder);
 
 export default router;

--- a/apps/backend/src/services/orderService.ts
+++ b/apps/backend/src/services/orderService.ts
@@ -1,6 +1,7 @@
 import { prisma } from "../../prisma/prisma";
 import { OrderStatus } from "@prisma/client";
 import { isValidObjectId } from "../repositories/validationRepository";
+import { createCheckoutSession } from "./stripeService";
 
 
 export const getOrderStatsService = async () => {
@@ -63,5 +64,7 @@ export const createOrderService = async (basket_id: string) => {
     },
   });
 
-  return order;
+  const checkout = await createCheckoutSession(basket_id);
+
+  return { order, checkout };
 };

--- a/apps/backend/src/services/orderService.ts
+++ b/apps/backend/src/services/orderService.ts
@@ -1,5 +1,6 @@
 import { prisma } from "../../prisma/prisma";
 import { OrderStatus } from "@prisma/client";
+import { isValidObjectId } from "../repositories/validationRepository";
 
 
 export const getOrderStatsService = async () => {
@@ -18,4 +19,49 @@ export const getOrderStatsService = async () => {
     activeOrders,
     shippingOrders,
   };
+};
+
+export const getOrdersService = async () => {
+  const orders = await prisma.order.findMany({
+    include: {
+      basket: {
+        include: { user: true, products: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+  return orders;
+};
+
+export const createOrderService = async (basket_id: string) => {
+  isValidObjectId(basket_id);
+
+  const basket = await prisma.basket.findUnique({
+    where: { id: basket_id },
+  });
+
+  if (!basket) {
+    throw new Error(`Basket with id ${basket_id} not found`);
+  }
+
+  if (basket.product_ids.length === 0) {
+    throw new Error("Cannot create an order from an empty basket");
+  }
+
+  const existingOrder = await prisma.order.findUnique({
+    where: { basket_id },
+  });
+
+  if (existingOrder) {
+    throw new Error(`An order already exists for basket ${basket_id}`);
+  }
+
+  const order = await prisma.order.create({
+    data: {
+      basket_id,
+      status: OrderStatus.PENDING,
+    },
+  });
+
+  return order;
 };

--- a/apps/backend/src/services/stripeService.ts
+++ b/apps/backend/src/services/stripeService.ts
@@ -1,0 +1,40 @@
+import { prisma } from "../../prisma/prisma";
+
+// Mock Stripe checkout for the demo. No real Stripe API is called and no
+// keys are needed. When STRIPE_SECRET_KEY is added later, this is the single
+// place to swap in a real stripe.checkout.sessions.create() call.
+
+export interface CheckoutSession {
+  sessionId: string;
+  checkoutUrl: string;
+  amountTotal: number;
+  currency: string;
+}
+
+export const createCheckoutSession = async (
+  basket_id: string
+): Promise<CheckoutSession> => {
+  const basket = await prisma.basket.findUnique({
+    where: { id: basket_id },
+    include: { products: true },
+  });
+
+  if (!basket) {
+    throw new Error(`Basket with id ${basket_id} not found`);
+  }
+
+  const amountTotal = basket.products.reduce(
+    (sum, product) => sum + product.price,
+    0
+  );
+
+  const sessionId = `cs_mock_${basket_id}`;
+  const checkoutUrl = `https://checkout.stripe.com/mock/${sessionId}`;
+
+  return {
+    sessionId,
+    checkoutUrl,
+    amountTotal,
+    currency: "sek",
+  };
+};

--- a/apps/backend/src/validators/order.ts
+++ b/apps/backend/src/validators/order.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const createOrderSchema = z.object({
+  basket_id: z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid basket_id"),
+});
+
+export type CreateOrderInput = z.infer<typeof createOrderSchema>;

--- a/apps/backend/src/validators/product.ts
+++ b/apps/backend/src/validators/product.ts
@@ -12,6 +12,9 @@ export const baseProductSchema = z.object({
     .int()
     .nonnegative("Stock must be a non-negative integer")
     .nullable(),
+  category: z.string().nullable().optional(),
+  size: z.array(z.string()).optional(),
+  image: z.string().nullable().optional(),
   basket_ids: z
     .array(z.string().regex(/^[0-9a-fA-F]{24}$/, "Invalid ObjectId")),
 });

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    // Demo: allow product images from any host.
+    remotePatterns: [
+      { protocol: "https", hostname: "**" },
+      { protocol: "http", hostname: "**" },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/apps/frontend/src/app/[slug]/page.tsx
+++ b/apps/frontend/src/app/[slug]/page.tsx
@@ -1,9 +1,10 @@
-import { getProductByTitle } from "@/lib/api";
-import { Button } from "../components/button";
+import { getBasket, getProductByTitle, getUserById } from "@/lib/api";
 import { Product } from "@/types/product";
 import Image from "next/image";
 import { Header } from "../components/header";
 import { SizePicker } from "../components/products/sizePicker";
+import { AddToCart } from "../components/products/addToCart";
+import { auth0 } from "@/lib/auth0";
 
 export default async function ProductPage({
   params,
@@ -11,9 +12,7 @@ export default async function ProductPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const response: Product | null = await getProductByTitle(slug);
-  console.log(response)
-  const product = response;
+  const product: Product | null = await getProductByTitle(slug);
 
   if (!product) {
     return (
@@ -23,25 +22,46 @@ export default async function ProductPage({
     );
   }
 
+  const session = await auth0.getSession();
+  let basketId: string | null = null;
+
+  if (session) {
+    try {
+      const user = await getUserById(session.user.sub);
+      const basket = await getBasket(user.id);
+      basketId = basket?.id ?? null;
+    } catch (error) {
+      console.error("Failed to load basket:", error);
+    }
+  }
+
   return (
     <>
-    <Header/>
-    <main className="flex flex-col justify-center lg:flex-row">
-    <Image alt={product.title} src={product.image || "/goldring.webp"} width={720} height={720} className="w-full max-w-[720px] h-auto object-cover"/>
-    <section className="flex flex-col px-4 py-2 gap-4 justify-center max-w-156">
-      <div>
-      <h2 className="font-medium text-3xl">{product.title}</h2>
-      <p className="font-medium text-2xl text-stone-700">{product.price} kr</p>
-      <p className="text-stone-600 pt-2">{product.introduction}</p>
-      </div>
-      <SizePicker sizes={product.size} />
-      <Button name="Add to cart" buttonType="click" color="primary" textColor="white"/>
-      <div className="flex flex-col gap-6">
-      <p className="text-stone-600">{product.body}</p>
-      <p>{product.description}</p>
-      </div>
-    </section>
-    </main>
+      <Header />
+      <main className="flex flex-col justify-center lg:flex-row">
+        <Image
+          alt={product.title}
+          src={product.image || "/goldring.webp"}
+          width={720}
+          height={720}
+          className="w-full max-w-[720px] h-auto object-cover"
+        />
+        <section className="flex flex-col px-4 py-2 gap-4 justify-center max-w-156">
+          <div>
+            <h2 className="font-medium text-3xl">{product.title}</h2>
+            <p className="font-medium text-2xl text-stone-700">
+              {product.price} kr
+            </p>
+            <p className="text-stone-600 pt-2">{product.introduction}</p>
+          </div>
+          <SizePicker sizes={product.size} />
+          <AddToCart basketId={basketId} productId={product.id} />
+          <div className="flex flex-col gap-6">
+            <p className="text-stone-600">{product.body}</p>
+            <p>{product.description}</p>
+          </div>
+        </section>
+      </main>
     </>
   );
 }

--- a/apps/frontend/src/app/[slug]/page.tsx
+++ b/apps/frontend/src/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "../components/button";
 import { Product } from "@/types/product";
 import Image from "next/image";
 import { Header } from "../components/header";
+import { SizePicker } from "../components/products/sizePicker";
 
 export default async function ProductPage({
   params,
@@ -33,6 +34,7 @@ export default async function ProductPage({
       <p className="font-medium text-2xl text-stone-700">{product.price} kr</p>
       <p className="text-stone-600 pt-2">{product.introduction}</p>
       </div>
+      <SizePicker sizes={product.size} />
       <Button name="Add to cart" buttonType="click" color="primary" textColor="white"/>
       <div className="flex flex-col gap-6">
       <p className="text-stone-600">{product.body}</p>

--- a/apps/frontend/src/app/[slug]/page.tsx
+++ b/apps/frontend/src/app/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function ProductPage({
     <>
     <Header/>
     <main className="flex flex-col justify-center lg:flex-row">
-    <Image alt="image of a ring" src="/goldring.webp" width={720} height={720}/>
+    <Image alt={product.title} src={product.image || "/goldring.webp"} width={720} height={720} className="w-full max-w-[720px] h-auto object-cover"/>
     <section className="flex flex-col px-4 py-2 gap-4 justify-center max-w-156">
       <div>
       <h2 className="font-medium text-3xl">{product.title}</h2>

--- a/apps/frontend/src/app/admin/orders/page.tsx
+++ b/apps/frontend/src/app/admin/orders/page.tsx
@@ -1,0 +1,67 @@
+import { getOrders } from "@/lib/api";
+import { OrderStatus } from "@/types/order";
+
+const statusClass = (status: OrderStatus) => {
+  const map: Record<OrderStatus, string> = {
+    PENDING: "bg-amber-100 text-amber-700",
+    ACTIVE: "bg-blue-100 text-blue-700",
+    COMPLETED: "bg-green-100 text-green-700",
+    CANCELLED: "bg-stone-200 text-stone-600",
+  };
+  return map[status] ?? "bg-stone-100 text-stone-600";
+};
+
+export default async function AdminOrdersPage() {
+  const orders = await getOrders();
+
+  return (
+    <main className="flex flex-col px-4 py-2 w-full">
+      <h2 className="text-2xl font-bold mb-4">Orders</h2>
+
+      {orders.length === 0 ? (
+        <p className="text-stone-500">No orders yet</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border border-stone-200 rounded-lg">
+            <thead className="bg-stone-50 text-left">
+              <tr>
+                <th className="p-3">Order</th>
+                <th className="p-3">Customer</th>
+                <th className="p-3">Items</th>
+                <th className="p-3">Total</th>
+                <th className="p-3">Status</th>
+                <th className="p-3">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.map((order) => {
+                const products = order.basket?.products ?? [];
+                const total = products.reduce((sum, p) => sum + p.price, 0);
+                return (
+                  <tr key={order.id} className="border-t border-stone-200">
+                    <td className="p-3 font-mono text-xs">
+                      {order.id.slice(-6)}
+                    </td>
+                    <td className="p-3">{order.basket?.user?.email ?? "—"}</td>
+                    <td className="p-3">{products.length}</td>
+                    <td className="p-3">{total} kr</td>
+                    <td className="p-3">
+                      <span
+                        className={`px-2 py-1 rounded-full text-xs font-medium ${statusClass(order.status)}`}
+                      >
+                        {order.status}
+                      </span>
+                    </td>
+                    <td className="p-3">
+                      {new Date(order.createdAt).toLocaleDateString("sv-SE")}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/frontend/src/app/admin/products/page.tsx
+++ b/apps/frontend/src/app/admin/products/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useEffect, useState } from "react";
+import { getProducts, deleteProduct } from "@/lib/api";
+import { Product } from "@/types/product";
+import { ProductForm } from "../../components/admin/productForm";
+
+export default function AdminProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [editing, setEditing] = useState<Product | null>(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const loadProducts = async () => {
+    const data = await getProducts();
+    setProducts(data);
+  };
+
+  useEffect(() => {
+    loadProducts();
+  }, []);
+
+  const handleSaved = () => {
+    setShowForm(false);
+    setEditing(null);
+    loadProducts();
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteProduct(id);
+      loadProducts();
+    } catch (error) {
+      console.error("Failed to delete product:", error);
+    }
+  };
+
+  const startCreate = () => {
+    setEditing(null);
+    setShowForm(true);
+  };
+
+  const startEdit = (product: Product) => {
+    setEditing(product);
+    setShowForm(true);
+  };
+
+  return (
+    <main className="flex flex-col px-4 py-2 w-full gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold">Products</h2>
+        <button
+          onClick={startCreate}
+          className="px-4 py-2 bg-primary text-white text-sm rounded"
+        >
+          New product
+        </button>
+      </div>
+
+      {showForm && (
+        <ProductForm
+          initial={editing}
+          onSaved={handleSaved}
+          onCancel={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      {products.length === 0 ? (
+        <p className="text-stone-500">No products yet</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {products.map((product) => (
+            <div
+              key={product.id}
+              className="flex flex-col gap-2 p-4 border border-stone-200 rounded-lg bg-white"
+            >
+              <div className="flex justify-between">
+                <span className="font-medium">{product.title}</span>
+                <span className="text-stone-600">{product.price} kr</span>
+              </div>
+              <span className="text-xs text-stone-500 uppercase">
+                {product.category || "uncategorized"}
+              </span>
+              <span className="text-xs text-stone-500">
+                Stock: {product.stock ?? "—"}
+              </span>
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={() => startEdit(product)}
+                  className="flex-1 px-3 py-1.5 bg-stone-100 text-stone-700 text-sm rounded hover:bg-stone-200"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(product.id)}
+                  className="flex-1 px-3 py-1.5 bg-stone-100 text-primary text-sm rounded hover:bg-stone-200"
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/frontend/src/app/basket/page.tsx
+++ b/apps/frontend/src/app/basket/page.tsx
@@ -3,6 +3,7 @@ import { auth0 } from "@/lib/auth0";
 import { getBasket, getUserById } from "@/lib/api";
 import { Basket } from "@/types/basket";
 import { BasketCard } from "../components/basket/basketCard";
+import { CheckoutButton } from "../components/basket/checkoutButton";
 import { redirect } from "next/navigation";
 
 export default async function BasketPage() {
@@ -48,6 +49,7 @@ export default async function BasketPage() {
               <span className="text-lg font-medium">Total</span>
               <span className="text-lg font-medium">{total} kr</span>
             </div>
+            <CheckoutButton basketId={basketId} />
           </>
         )}
       </main>

--- a/apps/frontend/src/app/basket/page.tsx
+++ b/apps/frontend/src/app/basket/page.tsx
@@ -1,0 +1,56 @@
+import { Header } from "../components/header";
+import { auth0 } from "@/lib/auth0";
+import { getBasket, getUserById } from "@/lib/api";
+import { Product } from "@/types/product";
+import { redirect } from "next/navigation";
+
+export default async function BasketPage() {
+  const session = await auth0.getSession();
+
+  if (!session) {
+    redirect("/auth/login");
+  }
+
+  let products: Product[] = [];
+
+  try {
+    const user = await getUserById(session.user.sub);
+    const basket = await getBasket(user.id);
+    products = basket?.products ?? [];
+  } catch (error) {
+    console.error("Failed to load basket:", error);
+  }
+
+  const total = products.reduce((sum, product) => sum + product.price, 0);
+
+  return (
+    <>
+      <Header />
+      <main className="flex flex-col px-4 py-6 gap-6 max-w-3xl mx-auto w-full">
+        <h1 className="font-medium">Your basket</h1>
+
+        {products.length === 0 ? (
+          <p className="text-stone-600">Your basket is empty.</p>
+        ) : (
+          <>
+            <div className="flex flex-col divide-y divide-stone-200">
+              {products.map((product) => (
+                <div
+                  key={product.id}
+                  className="flex items-center justify-between py-3"
+                >
+                  <span>{product.title}</span>
+                  <span className="font-medium">{product.price} kr</span>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-between border-t border-stone-200 pt-4">
+              <span className="text-lg font-medium">Total</span>
+              <span className="text-lg font-medium">{total} kr</span>
+            </div>
+          </>
+        )}
+      </main>
+    </>
+  );
+}

--- a/apps/frontend/src/app/basket/page.tsx
+++ b/apps/frontend/src/app/basket/page.tsx
@@ -1,7 +1,8 @@
 import { Header } from "../components/header";
 import { auth0 } from "@/lib/auth0";
 import { getBasket, getUserById } from "@/lib/api";
-import { Product } from "@/types/product";
+import { Basket } from "@/types/basket";
+import { BasketCard } from "../components/basket/basketCard";
 import { redirect } from "next/navigation";
 
 export default async function BasketPage() {
@@ -11,16 +12,17 @@ export default async function BasketPage() {
     redirect("/auth/login");
   }
 
-  let products: Product[] = [];
+  let basket: Basket | null = null;
 
   try {
     const user = await getUserById(session.user.sub);
-    const basket = await getBasket(user.id);
-    products = basket?.products ?? [];
+    basket = await getBasket(user.id);
   } catch (error) {
     console.error("Failed to load basket:", error);
   }
 
+  const products = basket?.products ?? [];
+  const basketId = basket?.id ?? "";
   const total = products.reduce((sum, product) => sum + product.price, 0);
 
   return (
@@ -35,13 +37,11 @@ export default async function BasketPage() {
           <>
             <div className="flex flex-col divide-y divide-stone-200">
               {products.map((product) => (
-                <div
+                <BasketCard
                   key={product.id}
-                  className="flex items-center justify-between py-3"
-                >
-                  <span>{product.title}</span>
-                  <span className="font-medium">{product.price} kr</span>
-                </div>
+                  basketId={basketId}
+                  product={product}
+                />
               ))}
             </div>
             <div className="flex items-center justify-between border-t border-stone-200 pt-4">

--- a/apps/frontend/src/app/components/admin/productForm.tsx
+++ b/apps/frontend/src/app/components/admin/productForm.tsx
@@ -37,10 +37,9 @@ export const ProductForm = ({ initial, onSaved, onCancel }: Props) => {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    const payload = {
+    const fields = {
       title,
       introduction: introduction || null,
-      body: null,
       description: description || null,
       price: Number(price),
       status: inStock,
@@ -48,14 +47,15 @@ export const ProductForm = ({ initial, onSaved, onCancel }: Props) => {
       category: category || null,
       size: sizeList,
       image: image || null,
-      basket_ids: [],
     };
 
     try {
       if (initial) {
-        await updateProduct(initial.id, payload);
+        // Only send the fields the form owns, so editing never wipes
+        // untouched fields (body) or basket relations (basket_ids).
+        await updateProduct(initial.id, fields);
       } else {
-        await createProduct(payload);
+        await createProduct({ ...fields, body: null, basket_ids: [] });
       }
       onSaved();
     } catch (err) {

--- a/apps/frontend/src/app/components/admin/productForm.tsx
+++ b/apps/frontend/src/app/components/admin/productForm.tsx
@@ -1,0 +1,160 @@
+"use client";
+import { useState } from "react";
+import { Product } from "@/types/product";
+import { createProduct, updateProduct } from "@/lib/api";
+
+type Props = {
+  initial?: Product | null;
+  onSaved: () => void;
+  onCancel: () => void;
+};
+
+const inputClass =
+  "border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary";
+
+export const ProductForm = ({ initial, onSaved, onCancel }: Props) => {
+  const [title, setTitle] = useState(initial?.title ?? "");
+  const [price, setPrice] = useState(initial ? String(initial.price) : "");
+  const [category, setCategory] = useState(initial?.category ?? "");
+  const [image, setImage] = useState(initial?.image ?? "");
+  const [stock, setStock] = useState(
+    initial?.stock != null ? String(initial.stock) : ""
+  );
+  const [sizes, setSizes] = useState((initial?.size ?? []).join(", "));
+  const [introduction, setIntroduction] = useState(initial?.introduction ?? "");
+  const [description, setDescription] = useState(initial?.description ?? "");
+  const [inStock, setInStock] = useState(initial?.status ?? true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+
+    const sizeList = sizes
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const payload = {
+      title,
+      introduction: introduction || null,
+      body: null,
+      description: description || null,
+      price: Number(price),
+      status: inStock,
+      stock: stock === "" ? null : Number(stock),
+      category: category || null,
+      size: sizeList,
+      image: image || null,
+      basket_ids: [],
+    };
+
+    try {
+      if (initial) {
+        await updateProduct(initial.id, payload);
+      } else {
+        await createProduct(payload);
+      }
+      onSaved();
+    } catch (err) {
+      console.error("Failed to save product:", err);
+      setError("Failed to save product. Check the fields and try again.");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col gap-3 p-4 border border-stone-200 rounded-lg bg-white"
+    >
+      <h3 className="font-semibold">
+        {initial ? "Edit product" : "New product"}
+      </h3>
+
+      <input
+        className={inputClass}
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        required
+      />
+      <div className="flex gap-3">
+        <input
+          className={`${inputClass} w-1/2`}
+          type="number"
+          placeholder="Price (kr)"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          required
+        />
+        <input
+          className={`${inputClass} w-1/2`}
+          type="number"
+          placeholder="Stock"
+          value={stock}
+          onChange={(e) => setStock(e.target.value)}
+        />
+      </div>
+      <input
+        className={inputClass}
+        placeholder="Category"
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+      />
+      <input
+        className={inputClass}
+        placeholder="Image URL"
+        value={image}
+        onChange={(e) => setImage(e.target.value)}
+      />
+      <input
+        className={inputClass}
+        placeholder="Sizes (comma separated)"
+        value={sizes}
+        onChange={(e) => setSizes(e.target.value)}
+      />
+      <input
+        className={inputClass}
+        placeholder="Short introduction"
+        value={introduction}
+        onChange={(e) => setIntroduction(e.target.value)}
+      />
+      <textarea
+        className={inputClass}
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={inStock}
+          onChange={(e) => setInStock(e.target.checked)}
+        />
+        In stock
+      </label>
+
+      {error && <p className="text-sm text-primary">{error}</p>}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-4 py-2 bg-primary text-white text-sm rounded disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 bg-stone-100 text-stone-700 text-sm rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/apps/frontend/src/app/components/basket/basketCard.tsx
+++ b/apps/frontend/src/app/components/basket/basketCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+import Image from "next/image";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { removeFromBasket } from "@/lib/api";
+import { Product } from "@/types/product";
+
+type Props = {
+  basketId: string;
+  product: Product;
+};
+
+export const BasketCard = ({ basketId, product }: Props) => {
+  const router = useRouter();
+  const [removing, setRemoving] = useState(false);
+
+  const handleRemove = async () => {
+    setRemoving(true);
+    try {
+      await removeFromBasket(basketId, product.id);
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to remove from basket:", error);
+      setRemoving(false);
+    }
+  };
+
+  return (
+    <article className="flex items-center gap-4 py-3">
+      <div className="relative w-20 h-20 shrink-0 bg-secondary/40">
+        <Image
+          src={product.image || "/elana_logo.svg"}
+          alt={product.title}
+          fill
+          sizes="80px"
+          className="object-cover"
+        />
+      </div>
+      <div className="flex flex-col grow">
+        <span className="font-medium">{product.title}</span>
+        {product.category && (
+          <span className="text-sm text-stone-500 uppercase">
+            {product.category}
+          </span>
+        )}
+      </div>
+      <span className="font-medium whitespace-nowrap">{product.price} kr</span>
+      <button
+        type="button"
+        onClick={handleRemove}
+        disabled={removing}
+        className="text-sm text-stone-500 hover:text-primary disabled:opacity-50 transition-colors"
+      >
+        {removing ? "Removing..." : "Remove"}
+      </button>
+    </article>
+  );
+};

--- a/apps/frontend/src/app/components/basket/checkoutButton.tsx
+++ b/apps/frontend/src/app/components/basket/checkoutButton.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useState } from "react";
+import { createOrder, type CheckoutSession } from "@/lib/api";
+import { Button } from "../button";
+
+type Props = {
+  basketId: string;
+};
+
+export const CheckoutButton = ({ basketId }: Props) => {
+  const [loading, setLoading] = useState(false);
+  const [session, setSession] = useState<CheckoutSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheckout = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const checkout = await createOrder(basketId);
+      setSession(checkout);
+    } catch (err) {
+      console.error("Checkout failed:", err);
+      setError("Checkout failed. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (session) {
+    return (
+      <div className="flex flex-col gap-1 items-end text-right">
+        <p className="font-medium text-primary">Order placed (mock checkout)</p>
+        <p className="text-sm text-stone-600 break-all">
+          {session.amountTotal} {session.currency.toUpperCase()} ·{" "}
+          {session.checkoutUrl}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 items-end">
+      <Button
+        name={loading ? "Placing order..." : "Checkout"}
+        buttonType="click"
+        color="primary"
+        textColor="white"
+        onClick={handleCheckout}
+      />
+      {error && <p className="text-sm text-primary">{error}</p>}
+    </div>
+  );
+};

--- a/apps/frontend/src/app/components/header.tsx
+++ b/apps/frontend/src/app/components/header.tsx
@@ -10,7 +10,7 @@ export const Header = () => {
       <Link href="/">
       <Image src="/elana_logo.svg" alt="logo" width="163" height="80"></Image>
       </Link>
-      <IconButton size="md" href="#" icon={ShoppingCart}></IconButton>
+      <IconButton size="md" href="/basket" icon={ShoppingCart}></IconButton>
     </nav>
   );
 };

--- a/apps/frontend/src/app/components/products/addToCart.tsx
+++ b/apps/frontend/src/app/components/products/addToCart.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { addToBasket } from "@/lib/api";
+import { Button } from "../button";
+
+type Props = {
+  basketId: string | null;
+  productId: string;
+};
+
+export const AddToCart = ({ basketId, productId }: Props) => {
+  const router = useRouter();
+  const [status, setStatus] = useState<"idle" | "loading" | "added">("idle");
+
+  if (!basketId) {
+    return (
+      <Button
+        name="Log in to add to cart"
+        buttonType="link"
+        route="/auth/login"
+        color="primary"
+        textColor="white"
+      />
+    );
+  }
+
+  const handleAdd = async () => {
+    setStatus("loading");
+    try {
+      await addToBasket(basketId, productId);
+      setStatus("added");
+      router.refresh();
+    } catch (error) {
+      console.error("Failed to add to cart:", error);
+      setStatus("idle");
+    }
+  };
+
+  const label =
+    status === "added"
+      ? "Added to cart"
+      : status === "loading"
+        ? "Adding..."
+        : "Add to cart";
+
+  return (
+    <Button
+      name={label}
+      buttonType="click"
+      color="primary"
+      textColor="white"
+      onClick={handleAdd}
+    />
+  );
+};

--- a/apps/frontend/src/app/components/products/categoryFilter.tsx
+++ b/apps/frontend/src/app/components/products/categoryFilter.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+type Props = {
+  categories: string[];
+  selected: string | null;
+  onSelect: (category: string | null) => void;
+};
+
+export const CategoryFilter = ({ categories, selected, onSelect }: Props) => {
+  if (categories.length === 0) {
+    return null;
+  }
+
+  const chip = (active: boolean) =>
+    `px-4 py-1.5 rounded-full text-sm border transition-colors ${
+      active
+        ? "bg-primary text-white border-primary"
+        : "bg-white text-stone-700 border-stone-300 hover:border-primary"
+    }`;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <button
+        type="button"
+        className={chip(selected === null)}
+        onClick={() => onSelect(null)}
+      >
+        All
+      </button>
+      {categories.map((category) => (
+        <button
+          key={category}
+          type="button"
+          className={chip(selected === category)}
+          onClick={() => onSelect(category)}
+        >
+          {category}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/apps/frontend/src/app/components/products/productCard.tsx
+++ b/apps/frontend/src/app/components/products/productCard.tsx
@@ -4,28 +4,26 @@ type Props = {
   image: string;
   title: string;
   price: number;
-  category?: string;
+  category?: string | null;
 };
-export const ProductCard = ({
-  image,
-  title,
-  price,
-  // category,
-}: Props) => {
+export const ProductCard = ({ image, title, price, category }: Props) => {
   return (
-    <Link href={`/${title}`} className="w-40 md:w-56 hover:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)] transition-shadow duration-200">
+    <Link
+      href={`/${title}`}
+      className="w-40 md:w-56 hover:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)] transition-shadow duration-200"
+    >
       <article className="flex flex-col h-full">
-        <div className="w-full relative">
-        <Image
-          src={image}
-          alt="product image"
-          width={96}
-          height={96}
-          className="w-96"
+        <div className="w-full relative aspect-square bg-secondary/40">
+          <Image
+            src={image}
+            alt={title}
+            fill
+            sizes="(max-width: 768px) 160px, 224px"
+            className="object-cover"
           />
-          </div>
+        </div>
         <div className="flex flex-col justify-between w-full h-full px-2 pt-6 pb-2">
-          <p className="text-sm text-stone-600 uppercase">silver</p>
+          <p className="text-sm text-stone-600 uppercase">{category || "elana"}</p>
           <p>{title}</p>
           <p className="text-xl font-medium">{price} kr</p>
         </div>

--- a/apps/frontend/src/app/components/products/productCard.tsx
+++ b/apps/frontend/src/app/components/products/productCard.tsx
@@ -9,7 +9,7 @@ type Props = {
 export const ProductCard = ({ image, title, price, category }: Props) => {
   return (
     <Link
-      href={`/${title}`}
+      href={`/${encodeURIComponent(title)}`}
       className="w-40 md:w-56 hover:shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)] transition-shadow duration-200"
     >
       <article className="flex flex-col h-full">

--- a/apps/frontend/src/app/components/products/productDisplay.tsx
+++ b/apps/frontend/src/app/components/products/productDisplay.tsx
@@ -12,9 +12,10 @@ export const ProductDisplay = ({
         products.map((product: Product) => (
           <ProductCard
             key={product.id}
-            image="/elana_logo.svg"
+            image={product.image || "/elana_logo.svg"}
             title={product.title}
             price={product.price}
+            category={product.category}
           />
         ))
       ) : (

--- a/apps/frontend/src/app/components/products/sizePicker.tsx
+++ b/apps/frontend/src/app/components/products/sizePicker.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useState } from "react";
+
+type Props = {
+  sizes: string[];
+};
+
+export const SizePicker = ({ sizes }: Props) => {
+  const [selected, setSelected] = useState<string | null>(sizes[0] ?? null);
+
+  if (sizes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-medium text-stone-700">Size</p>
+      <div className="flex flex-wrap gap-2">
+        {sizes.map((size) => (
+          <button
+            key={size}
+            type="button"
+            onClick={() => setSelected(size)}
+            className={`min-w-12 px-4 py-2 border text-sm transition-colors ${
+              selected === size
+                ? "border-primary bg-primary text-white"
+                : "border-stone-300 hover:border-primary"
+            }`}
+          >
+            {size}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/app/components/profile/profilePanel.tsx
+++ b/apps/frontend/src/app/components/profile/profilePanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+import { useState } from "react";
+import { updateUser, deleteUser } from "@/lib/api";
+
+type Props = {
+  userId: string;
+  email: string;
+  role: string;
+};
+
+export const ProfilePanel = ({ userId, email, role }: Props) => {
+  const [currentEmail, setCurrentEmail] = useState(email);
+  const [draftEmail, setDraftEmail] = useState(email);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateUser(userId, { email: draftEmail });
+      setCurrentEmail(updated.email ?? draftEmail);
+      setEditing(false);
+    } catch (err) {
+      console.error("Failed to update profile:", err);
+      setError("Could not update profile.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await deleteUser(userId);
+      window.location.href = "/auth/logout";
+    } catch (err) {
+      console.error("Failed to delete profile:", err);
+      setError("Could not delete profile.");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-6 border border-stone-200 rounded-2xl bg-white shadow-sm">
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-stone-500 font-medium uppercase">
+          Email
+        </span>
+        {editing ? (
+          <div className="flex gap-2">
+            <input
+              type="email"
+              value={draftEmail}
+              onChange={(e) => setDraftEmail(e.target.value)}
+              className="grow border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-2 bg-primary text-white text-sm rounded disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+            <button
+              onClick={() => {
+                setEditing(false);
+                setDraftEmail(currentEmail);
+              }}
+              className="px-3 py-2 bg-stone-100 text-stone-700 text-sm rounded"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <span>{currentEmail}</span>
+            <button
+              onClick={() => setEditing(true)}
+              className="text-sm text-primary hover:underline"
+            >
+              Edit
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-stone-500 font-medium uppercase">
+          Role
+        </span>
+        <span className="text-sm capitalize">{role}</span>
+      </div>
+
+      {error && <p className="text-sm text-primary">{error}</p>}
+
+      <div className="border-t border-stone-200 pt-4">
+        {confirmingDelete ? (
+          <div className="flex flex-col gap-2">
+            <p className="text-sm text-stone-600">
+              Are you sure? This permanently removes your account.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={handleDelete}
+                disabled={saving}
+                className="px-3 py-2 bg-primary text-white text-sm rounded disabled:opacity-50"
+              >
+                Yes, delete
+              </button>
+              <button
+                onClick={() => setConfirmingDelete(false)}
+                className="px-3 py-2 bg-stone-100 text-stone-700 text-sm rounded"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setConfirmingDelete(true)}
+            className="text-sm text-primary hover:underline"
+          >
+            Delete account
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -39,35 +39,51 @@ export default function Home() {
 
   return (
     <main>
-      <Header></Header>
-      <section className="bg-secondary h-96 flex items-center p-4">
-        <h1 className="font-medium">
-          <span className="text-primary">New</span> season.
-          <br />
-          Never known <span className="text-primary">designs</span>.
-        </h1>
+      <Header />
+
+      <section className="bg-secondary">
+        <div className="max-w-6xl mx-auto px-6 py-16 md:py-24 flex flex-col gap-4">
+          <span className="text-primary text-sm font-medium tracking-[0.2em] uppercase">
+            New season
+          </span>
+          <h1 className="font-medium text-4xl md:text-5xl max-w-2xl leading-tight">
+            Timeless pieces,
+            <br />
+            <span className="text-primary">never known</span> designs.
+          </h1>
+          <p className="text-stone-600 max-w-xl">
+            Handpicked jewelry for every day and every occasion.
+          </p>
+        </div>
       </section>
-      <section className="p-4 flex flex-col gap-4">
-        <SearchBar
-          onSearch={async (query) => {
-            try {
-              const result = await getProductsByTitle(query);
-              setProducts(result ?? []);
-              setCategory(null);
-            } catch (error: unknown) {
-              console.error("Search failed:", error);
-              setProducts([]);
-            }
-          }}
-          placeholder="search..."
-        />
-        <CategoryFilter
-          categories={categories}
-          selected={category}
-          onSelect={setCategory}
-        />
-      </section>
-      <ProductDisplay products={visibleProducts} />
+
+      <div className="max-w-6xl mx-auto w-full px-6 py-8 flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <SearchBar
+            onSearch={async (query) => {
+              try {
+                const result = await getProductsByTitle(query);
+                setProducts(result ?? []);
+                setCategory(null);
+              } catch (error: unknown) {
+                console.error("Search failed:", error);
+                setProducts([]);
+              }
+            }}
+            placeholder="Search products..."
+          />
+          <CategoryFilter
+            categories={categories}
+            selected={category}
+            onSelect={setCategory}
+          />
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <h2 className="text-xl font-medium">New arrivals</h2>
+          <ProductDisplay products={visibleProducts} />
+        </div>
+      </div>
     </main>
   );
 }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,19 +1,20 @@
 "use client";
 import "./globals.css";
 import { Header } from "./components/header";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getProducts, getProductsByTitle } from "@/lib/api";
 import { Product } from "@/types/product";
 import { ProductDisplay } from "./components/products/productDisplay";
+import { CategoryFilter } from "./components/products/categoryFilter";
 import { SearchBar } from "./components/searchBar";
 
 export default function Home() {
   const [products, setProducts] = useState<Product[]>([]);
+  const [category, setCategory] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchProducts() {
       try {
-        console.log("GEt products")
         const data = await getProducts();
         setProducts(data);
       } catch (error: unknown) {
@@ -23,6 +24,18 @@ export default function Home() {
 
     fetchProducts();
   }, []);
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>();
+    for (const product of products) {
+      if (product.category) unique.add(product.category);
+    }
+    return Array.from(unique);
+  }, [products]);
+
+  const visibleProducts = category
+    ? products.filter((product) => product.category === category)
+    : products;
 
   return (
     <main>
@@ -34,13 +47,13 @@ export default function Home() {
           Never known <span className="text-primary">designs</span>.
         </h1>
       </section>
-      <section className="p-4">
+      <section className="p-4 flex flex-col gap-4">
         <SearchBar
           onSearch={async (query) => {
             try {
               const result = await getProductsByTitle(query);
-              console.log(result);
               setProducts(result ?? []);
+              setCategory(null);
             } catch (error: unknown) {
               console.error("Search failed:", error);
               setProducts([]);
@@ -48,8 +61,13 @@ export default function Home() {
           }}
           placeholder="search..."
         />
+        <CategoryFilter
+          categories={categories}
+          selected={category}
+          onSelect={setCategory}
+        />
       </section>
-      <ProductDisplay products={products} />
+      <ProductDisplay products={visibleProducts} />
     </main>
   );
 }

--- a/apps/frontend/src/app/profile/page.tsx
+++ b/apps/frontend/src/app/profile/page.tsx
@@ -1,8 +1,10 @@
 import { Header } from "@/app/components/header";
 import { auth0 } from "@/lib/auth0";
+import { getUserById } from "@/lib/api";
+import { User } from "@/types/user";
 import { redirect } from "next/navigation";
+import { ProfilePanel } from "../components/profile/profilePanel";
 import { Button } from "../components/button";
-import Image from "next/image";
 
 export default async function ProfilePage() {
   const session = await auth0.getSession();
@@ -11,20 +13,49 @@ export default async function ProfilePage() {
     redirect("/auth/login");
   }
 
-  const user = session?.user;
+  const authUser = session.user;
+
+  let dbUser: User | null = null;
+  try {
+    dbUser = await getUserById(authUser.sub);
+  } catch (error) {
+    console.error("Failed to load profile:", error);
+  }
+
+  const initial = (authUser.name || authUser.email || "?")
+    .charAt(0)
+    .toUpperCase();
+
   return (
     <>
       <Header />
-      <main className="flex flex-col justify-center">
-        <section className="flex flex-col px-4 py-2 gap-4 justify-center max-w-156">
-          <h1>Hello, {user.name || user.nickname}!</h1>
-          <p>{user.email}</p>
+      <main className="flex flex-col items-center px-4 py-10">
+        <section className="w-full max-w-md flex flex-col gap-6">
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-20 h-20 rounded-full bg-primary text-white flex items-center justify-center text-2xl font-medium">
+              {initial}
+            </div>
+            <h1 className="font-medium">{authUser.name || authUser.nickname}</h1>
+          </div>
+
+          {dbUser ? (
+            <ProfilePanel
+              userId={dbUser.id}
+              email={dbUser.email}
+              role={dbUser.role}
+            />
+          ) : (
+            <p className="text-stone-600 text-center">
+              We could not load your account details.
+            </p>
+          )}
+
           <Button
-            name="logout"
-            color="primary"
+            name="Log out"
+            color="secondary"
             route="/auth/logout"
             buttonType="link"
-            textColor="white"
+            textColor="black"
           />
         </section>
       </main>

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -135,3 +135,15 @@ export async function removeFromBasket(
     data: { basket_id: basketId, product_id: productId },
   });
 }
+
+export interface CheckoutSession {
+  sessionId: string;
+  checkoutUrl: string;
+  amountTotal: number;
+  currency: string;
+}
+
+export async function createOrder(basketId: string): Promise<CheckoutSession> {
+  const res = await api.post("/orders", { basket_id: basketId });
+  return res.data.checkout;
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -159,3 +159,34 @@ export async function getOrders(): Promise<Order[]> {
     return [];
   }
 }
+
+export type ProductInput = {
+  title: string;
+  introduction: string | null;
+  body: string | null;
+  description: string | null;
+  price: number;
+  status: boolean | null;
+  stock: number | null;
+  category: string | null;
+  size: string[];
+  image: string | null;
+  basket_ids: string[];
+};
+
+export async function createProduct(data: ProductInput): Promise<Product> {
+  const res = await api.post("/product/create", data);
+  return res.data;
+}
+
+export async function updateProduct(
+  id: string,
+  data: Partial<ProductInput>
+): Promise<Product> {
+  const res = await api.put(`/product/${id}`, data);
+  return res.data.data;
+}
+
+export async function deleteProduct(id: string): Promise<void> {
+  await api.delete(`/product/${id}`);
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -126,3 +126,12 @@ export async function addToBasket(
     product_id: productId,
   });
 }
+
+export async function removeFromBasket(
+  basketId: string,
+  productId: string
+): Promise<void> {
+  await api.delete("/basket/remove-product", {
+    data: { basket_id: basketId, product_id: productId },
+  });
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -59,7 +59,7 @@ export async function getProductsByTitle(query: string): Promise<Product[]> {
 
 export async function getProductByTitle(query: string): Promise<Product | null> {
   try {
-    const res = await api.get(`/product/${query}`);
+    const res = await api.get(`/product/${encodeURIComponent(query)}`);
     const product = res.data.data;
     console.log(product)
     return product;

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -116,3 +116,13 @@ export async function getBasket(userId: string): Promise<Basket | null> {
     return null;
   }
 }
+
+export async function addToBasket(
+  basketId: string,
+  productId: string
+): Promise<void> {
+  await api.post("/basket/add-product", {
+    basket_id: basketId,
+    product_id: productId,
+  });
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import { Product } from "@/types/product";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 import { User } from "@/types/user";
 import { Basket } from "@/types/basket";
+import { Order } from "@/types/order";
 import axios from "axios";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:3013";
@@ -146,4 +147,15 @@ export interface CheckoutSession {
 export async function createOrder(basketId: string): Promise<CheckoutSession> {
   const res = await api.post("/orders", { basket_id: basketId });
   return res.data.checkout;
+}
+
+export async function getOrders(): Promise<Order[]> {
+  try {
+    const res = await api.get("/orders");
+    const orders = res.data.data;
+    return Array.isArray(orders) ? orders : [];
+  } catch (error) {
+    console.error("Error fetching orders:", error);
+    return [];
+  }
 }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { Product } from "@/types/product";
 import { getAccessToken } from "@auth0/nextjs-auth0";
 import { User } from "@/types/user";
+import { Basket } from "@/types/basket";
 import axios from "axios";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:3013";
@@ -103,5 +104,15 @@ export async function getUserById(id: string): Promise<User> {
   } catch (error) {
     console.error("Error fetching user:", error);
     throw error;
+  }
+}
+
+export async function getBasket(userId: string): Promise<Basket | null> {
+  try {
+    const res = await api.get(`/basket/${userId}`);
+    return res.data.data;
+  } catch (error) {
+    console.error("Error fetching basket:", error);
+    return null;
   }
 }

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -190,3 +190,7 @@ export async function updateProduct(
 export async function deleteProduct(id: string): Promise<void> {
   await api.delete(`/product/${id}`);
 }
+
+export async function deleteUser(id: string): Promise<void> {
+  await api.delete(`/users/${id}`);
+}

--- a/apps/frontend/src/types/basket.ts
+++ b/apps/frontend/src/types/basket.ts
@@ -1,0 +1,10 @@
+import { Product } from "./product";
+
+export type Basket = {
+  id: string;
+  user_id: string;
+  product_ids: string[];
+  products: Product[];
+  createdAt: string;
+  updatedAt: string;
+};

--- a/apps/frontend/src/types/order.ts
+++ b/apps/frontend/src/types/order.ts
@@ -1,0 +1,17 @@
+import { Product } from "./product";
+import { User } from "./user";
+
+export type OrderStatus = "PENDING" | "ACTIVE" | "COMPLETED" | "CANCELLED";
+
+export type Order = {
+  id: string;
+  basket_id: string;
+  status: OrderStatus;
+  createdAt: string;
+  updatedAt: string;
+  basket?: {
+    id: string;
+    user?: User | null;
+    products?: Product[];
+  } | null;
+};

--- a/apps/frontend/src/types/product.ts
+++ b/apps/frontend/src/types/product.ts
@@ -9,5 +9,8 @@ export type Product = {
   description: string | null;
   status: boolean | null;
   stock: number | null;
+  category: string | null;
+  size: string[];
+  image: string | null;
   basket_ids: string[];
 };


### PR DESCRIPTION
## Finish ELANA — all open issues

Closes #98, #14, #36, #112, #102, #101, #100, #94, #95, #96, #97, #99, #110, #111

One combined branch, one commit per issue, in dependency order. Demo-level code that keeps to the existing slice architecture (routes → controller → service → validator) and the RabbitMQ async theme. Files are split, not merged into mega-files.

### Backend
- **#98** `category`, `size` (String[]), `image` on the Prisma `Product` model + zod validator + frontend type. Foundation for the product frontend work.
- **#14** `POST /orders` (create order from a basket, saved in Mongo, status `PENDING`) and `GET /orders` (list with basket → user + products). New `orderController`/`orderService`/`validators/order.ts`.
- **#36** `stripeService.ts` — mock checkout: sums the basket's product prices and returns a fake Stripe checkout URL. No real Stripe, no keys needed; single place to swap in a real `checkout.sessions.create()` later.
- **#112** create-order and mock checkout wired together — `POST /orders` returns the order **and** the checkout session.
- **route fix** `basketRouter`: moved `/add-product` and `/remove-product` above `/:id` so they are no longer shadowed by the param route.

### Frontend
- **#102** real product images (`next/image` + `remotePatterns` so any host works), with fallback assets.
- **#101** `SizePicker` on the product page (selectable sizes from `product.size`).
- **#100** `CategoryFilter` chips on the home page.
- **#94** `/basket` page (auth-guarded), cart icon links to it.
- **#95** `AddToCart` client component + `addToBasket` fetch.
- **#96** `BasketCard` (image, title, price, remove) + `CheckoutButton` that creates the order and shows the mock checkout — completes the product → basket → order loop.
- **#97** `/admin/orders` order list (customer, items, total, status badge, date).
- **#99** `/admin/products` panel: list + create/edit/delete via `ProductForm`.
- **#110** profile redesign with update email + delete account.
- **#111** home page hero + layout redesign (kept the search/filter logic).

### Notes
- **Stripe is a mock** (as agreed) — it returns a fake checkout URL and does not charge anything.
- Redesigns (#110/#111) were done in code with the existing design tokens (`primary #A8333B`, `secondary #F4E9D8`) since the Figma links weren't available.
- Size selection on the product page is presentational — the basket model stores product ids only, so size isn't persisted per line (demo scope).
- Both apps type-check clean (`tsc --noEmit`).
- Reviewed with a multi-agent adversarial pass; the one confirmed finding (product titles weren't URL-encoded in the card link / lookup, which the free-text admin form could break) is fixed.
