### PR TITLE
Fix production build and orders endpoint

### DIFF
--- a/apps/backend/src/services/orderService.ts
+++ b/apps/backend/src/services/orderService.ts
@@ -23,15 +23,37 @@ export const getOrderStatsService = async () => {
 };
 
 export const getOrdersService = async () => {
-  const orders = await prisma.order.findMany({
-    include: {
+  // Join in JS instead of nested includes: Basket.user is a required relation,
+  // so a nested include throws if any referenced user/basket was deleted
+  // (MongoDB does not enforce referential integrity). This tolerates orphans.
+  const [orders, baskets, users, products] = await Promise.all([
+    prisma.order.findMany({ orderBy: { createdAt: "desc" } }),
+    prisma.basket.findMany(),
+    prisma.user.findMany(),
+    prisma.product.findMany(),
+  ]);
+
+  const basketById = new Map(baskets.map((b) => [b.id, b]));
+  const userById = new Map(users.map((u) => [u.id, u]));
+  const productById = new Map(products.map((p) => [p.id, p]));
+
+  return orders.map((order) => {
+    const basket = basketById.get(order.basket_id);
+    if (!basket) {
+      return { ...order, basket: null };
+    }
+    return {
+      ...order,
       basket: {
-        include: { user: true, products: true },
+        ...basket,
+        user: userById.get(basket.user_id) ?? null,
+        products: basket.product_ids.flatMap((id) => {
+          const product = productById.get(id);
+          return product ? [product] : [];
+        }),
       },
-    },
-    orderBy: { createdAt: "desc" },
+    };
   });
-  return orders;
 };
 
 export const createOrderService = async (basket_id: string) => {

--- a/apps/frontend/src/app/admin/orders/page.tsx
+++ b/apps/frontend/src/app/admin/orders/page.tsx
@@ -1,6 +1,10 @@
 import { getOrders } from "@/lib/api";
 import { OrderStatus } from "@/types/order";
 
+// Fetches live data, so render at request time instead of at build time
+// (static prerendering has no backend to call and times the build out).
+export const dynamic = "force-dynamic";
+
 const statusClass = (status: OrderStatus) => {
   const map: Record<OrderStatus, string> = {
     PENDING: "bg-amber-100 text-amber-700",


### PR DESCRIPTION
Two fixes that landed on the branch after #113 was merged:

- **fix: force dynamic rendering on admin orders page** — the Vercel production build timed out trying to statically prerender /admin/orders (it fetches live data with no backend available at build time). One line: `export const dynamic = "force-dynamic"`. Verified with a clean local `next build` (14/14 pages).
- **fix: tolerate orphaned basket/user refs in GET /orders** — real data contains an order whose basket user was deleted; the nested include on the required Basket.user relation made Prisma throw 500. Now joins in JS and returns null for missing refs. Verified locally against Atlas.

Unblocks the production deploy on Vercel + Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)