### PR TITLE
Survive missing RabbitMQ in production

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -69,7 +69,7 @@ app.listen(port, host, () => {
 
 setInterval(async () => {
   try {
-    const res = await fetch("https://u10.onrender.com");
+    const res = await fetch("https://elana.onrender.com");
     console.log(`Self ping OK: ${res.status}`);
   } catch (error) {
     console.error("Could not self ping:", error);

--- a/apps/backend/src/queues/connection.ts
+++ b/apps/backend/src/queues/connection.ts
@@ -5,18 +5,27 @@ const QUEUE_NAME = process.env.RABBITMQ_QUEUE!;
 let channel: amqp.Channel | null = null;
 
 export const connectRabbitMQ = async () => {
-  const connection = await amqp.connect(process.env.RABBITMQ_URL || "");
-  channel = await connection.createChannel();
-  await channel.assertQueue(QUEUE_NAME, { durable: true });
+  // Never crash the API if the broker is unreachable (e.g. free tier
+  // without RabbitMQ) — queue features are simply disabled.
+  try {
+    const connection = await amqp.connect(process.env.RABBITMQ_URL || "");
+    channel = await connection.createChannel();
+    await channel.assertQueue(QUEUE_NAME, { durable: true });
 
-  console.log("Connected to RabbitMQ");
+    console.log("Connected to RabbitMQ");
 
-  connection.on("error", (err) =>
-    console.error("RabbitMQ connection error:", err)
-  );
-  connection.on("close", () => console.log("Disconnected from RabbitMQ"));
+    connection.on("error", (err) =>
+      console.error("RabbitMQ connection error:", err)
+    );
+    connection.on("close", () => console.log("Disconnected from RabbitMQ"));
 
-  await basketHandler(channel);
+    await basketHandler(channel);
+  } catch (error) {
+    console.error(
+      "RabbitMQ unavailable, queue features disabled:",
+      error instanceof Error ? error.message : error
+    );
+  }
 };
 
 export const publishToQueue = async (message: { event: string; data: BasketMessage | unknown}) => {


### PR DESCRIPTION
Render production fix:

- connectRabbitMQ wraps everything in try/catch: if the broker is unreachable the API keeps running and queue features are disabled, instead of the process crashing.
- Self ping now targets elana.onrender.com (the actual service) so the free instance stays awake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)